### PR TITLE
Add .env.template for the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ npm install
 
 3. Set up the environment variables:
 
-Create a `.env` file in the `server` directory and add the following:
+Copy the `.env.template` file to `.env` in the `server` directory:
+
+```bash
+cp .env.template .env
+```
+
+Fill in your OpenAI API key in the `.env` file:
 
 ```
 OPENAI_API_KEY=your_openai_api_key
 ```
-
-Replace `your_openai_api_key` with your actual OpenAI API key.
 
 4. Start the server:
 

--- a/server/.env.template
+++ b/server/.env.template
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key


### PR DESCRIPTION
Fixes #3

Add `.env.template` file and update `README.md` for environment setup.

* **Add `.env.template` file:**
  - Create `server/.env.template` with `OPENAI_API_KEY` placeholder.

* **Update `README.md`:**
  - Instruct users to copy `.env.template` to `.env`.
  - Instruct users to fill in their OpenAI API key in the `.env` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hideya/test-chatly-ai-gw/pull/4?shareId=7fc63a10-bbd2-47ef-a3a1-54f7a30c1613).