### PR TITLE
Make the server default port configurable via .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Copy the `.env.template` file to `.env` in the `server` directory:
 cp .env.template .env
 ```
 
-Fill in your OpenAI API key in the `.env` file:
+Fill in your OpenAI API key and the server port in the `.env` file:
 
 ```
 OPENAI_API_KEY=your_openai_api_key
+PORT=5000
 ```
 
 5. Start the server:
@@ -95,4 +96,4 @@ npm start
 npm run clean
 ```
 
-The server should now be running at `http://localhost:5000`.
+The server should now be running at `http://localhost:5000` (or the port specified in the `.env` file).

--- a/server/.env.template
+++ b/server/.env.template
@@ -1,1 +1,5 @@
+# OpenAI API key
 OPENAI_API_KEY=your_openai_api_key
+
+# Server port configuration
+PORT=5000


### PR DESCRIPTION
Fixes #21

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hideya/test-chatly-ai-gw/pull/22?shareId=7bf4c868-1df2-46ad-8aec-a465b551ca47).